### PR TITLE
Add "allowBreak" support

### DIFF
--- a/dist/mhchemParser.js
+++ b/dist/mhchemParser.js
@@ -39,7 +39,7 @@ var mhchemParser = (function () {
     function mhchemParser() {
     }
     mhchemParser.toTex = function (input, type) {
-        return _mhchemTexify.go(_mhchemParser.go(input, type), type !== "tex");
+        return _mhchemTexify.go(_mhchemParser.go(input, type), false);
     };
     return mhchemParser;
 }());
@@ -1440,7 +1440,14 @@ var _mhchemTexify = {
                 res += inputi;
             }
             else {
+                var allowBreak = _mhchemTexify._goAllowBreak(inputi);
+                if (allowBreak !== false && !/\\allowbreak$/.test(res)) {
+                    res += allowBreak;
+                }
                 res += _mhchemTexify._go2(inputi);
+                if (allowBreak !== false) {
+                    res += allowBreak;
+                }
                 if (inputi.type_ === '1st-level escape') {
                     cee = true;
                 }
@@ -1691,6 +1698,18 @@ var _mhchemTexify = {
             default:
                 assertNever(buf);
                 throw ["MhchemBugT", "mhchem bug T. Please report."];
+        }
+        return res;
+    },
+    _goAllowBreak: function (buf) {
+        var res;
+        switch (buf.type_) {
+            case 'arrow':
+            case 'operator':
+                res = '\\allowbreak';
+                break;
+            default:
+                res = false;
         }
         return res;
     },

--- a/esm/mhchemParser.js
+++ b/esm/mhchemParser.js
@@ -34,7 +34,7 @@
  */
 export class mhchemParser {
     static toTex(input, type) {
-        return _mhchemTexify.go(_mhchemParser.go(input, type), type !== "tex");
+        return _mhchemTexify.go(_mhchemParser.go(input, type), false);
     }
 }
 function _mhchemCreateTransitions(o) {
@@ -1433,7 +1433,14 @@ const _mhchemTexify = {
                 res += inputi;
             }
             else {
+                const allowBreak = _mhchemTexify._goAllowBreak(inputi);
+                if (allowBreak !== false && !/\\allowbreak$/.test(res)) {
+                    res += allowBreak;
+                }
                 res += _mhchemTexify._go2(inputi);
+                if (allowBreak !== false) {
+                    res += allowBreak;
+                }
                 if (inputi.type_ === '1st-level escape') {
                     cee = true;
                 }
@@ -1684,6 +1691,18 @@ const _mhchemTexify = {
             default:
                 assertNever(buf);
                 throw ["MhchemBugT", "mhchem bug T. Please report."];
+        }
+        return res;
+    },
+    _goAllowBreak: function (buf) {
+        let res;
+        switch (buf.type_) {
+            case 'arrow':
+            case 'operator':
+                res = '\\allowbreak';
+                break;
+            default:
+                res = false;
         }
         return res;
     },

--- a/package.json
+++ b/package.json
@@ -8,5 +8,10 @@
     "repository": "github:mhchem/mhchemParser",
     "license": "Apache-2.0",
     "author": "Martin Hensel",
-    "main": "dist/mhchemParser.js"
+    "main": "dist/mhchemParser.js",
+    "scripts": {
+        "build": "npm run build:cjs && npm run build:esm",
+        "build:cjs": "tsc -p ./tsconfig.json --outDir ./dist",
+        "build:esm": "tsc -p ./tsconfig-es6.json --outDir ./esm"
+    }
 }

--- a/playground.html
+++ b/playground.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<!--
+ **************************************************************************
+ *
+ *  mhchemParser.ts
+ *  4.2.2
+ *
+ *  Parser for the \ce command and \pu command for MathJax and Co.
+ *
+ *  mhchem's \ce is a tool for writing beautiful chemical equations easily.
+ *  mhchem's \pu is a tool for writing physical units easily.
+ *
+ *  -----------------------------------------------------------------------
+ *
+ *  Copyright 2015-2023 Martin Hensel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      or in file LICENSE.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  -----------------------------------------------------------------------
+ *
+ *  https://github.com/mhchem/mhchemParser
+ *
+ **************************************************************************
+-->
+<html>
+<head>
+	<meta charset="utf-8">
+	<script>
+		var exports = {};
+	</script>
+    <script>
+        MathJax = {
+            svg: {
+                displayOverflow: 'linebreak'
+            }
+        };
+    </script>
+    <script type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@4.0.0-beta.7/tex-svg.js"></script>
+	<script src="../dist/mhchemParser.js"></script>
+</head>
+<body>
+	<h1>mhchem Parser – Playground</h1>
+    <div>
+        <textarea id="textarea">Hg^2+ ->[I-] HgI2 ->[I-] [Hg^{II}I4]^2-</textarea>
+        <button id="button">click</button>
+    </div>
+	<div id="output"><span style="color: red">Could not load parser. This is likely a CORS restriction, e.g. if you opened this document via file://.</span></div>
+	<script>
+        const output = document.getElementById('output');
+        const textarea = document.getElementById('textarea');
+        const button = document.getElementById('button');
+        
+        output.innerHTML = '';
+        const raw = document.createElement('div');
+        output.appendChild(raw);
+        const svg = document.createElement('div');
+        output.appendChild(svg); 
+
+        button.onclick = () => {
+            const text = textarea.value;
+            const tex = mhchemParser.toTex(text);
+            raw.innerHTML = '\\(' + tex + '\\)';
+            svg.innerHTML = '\\(' + tex + '\\)';
+            MathJax.typesetPromise([svg])
+        }
+	</script>
+</body>
+</html>

--- a/src/mhchemParser.d.ts
+++ b/src/mhchemParser.d.ts
@@ -280,6 +280,7 @@ interface MhchemTexify {
 	go: { (input: Parsed[] | undefined, isInner?: boolean): string; };
 	_goInner: { (input: Parsed[]): string};
 	_go2: { (input: ParsedWithoutString): string };
+	_goAllowBreak: { (input: ParsedWithoutString): string | false };
 	_getArrow: { (input: ArrowName): string };
 	_getBond: { (input: BondName): string };
 	_getOperator: { (input: OperatorName): string };

--- a/src/mhchemParser.ts
+++ b/src/mhchemParser.ts
@@ -35,7 +35,7 @@
 
 export class mhchemParser {
 	static toTex(input: string, type: "tex" | "ce" | "pu"): string {
-		return _mhchemTexify.go(_mhchemParser.go(input, type), type !== "tex");
+		return _mhchemTexify.go(_mhchemParser.go(input, type), false);
 	}
 }
 
@@ -1305,7 +1305,14 @@ const _mhchemTexify: MhchemTexify = {
 			if (typeof inputi === "string") {
 				res += inputi;
 			} else {
+				const allowBreak = _mhchemTexify._goAllowBreak(inputi);
+				if (allowBreak !== false && !/\\allowbreak$/.test(res)) {
+					res += allowBreak;
+				}
 				res += _mhchemTexify._go2(inputi);
+				if (allowBreak !== false) {
+					res += allowBreak;
+				}
 				if (inputi.type_ === '1st-level escape') { cee = true; }
 			}
 		}
@@ -1553,6 +1560,18 @@ const _mhchemTexify: MhchemTexify = {
 			default:
 				assertNever(buf);
 				throw ["MhchemBugT", "mhchem bug T. Please report."];  // Missing mhchemTexify rule or unknown MhchemParser output
+		}
+		return res;
+	},
+	_goAllowBreak: function (buf) {
+		let res: string | false;
+		switch (buf.type_) {
+			case 'arrow':
+			case 'operator':
+				res = '\\allowbreak'
+				break;
+			default:
+				res = false;
 		}
 		return res;
 	},


### PR DESCRIPTION
Mathjax v4 has added support for line breaks. I make an experimental adaptation for this feature (by adding some allowbreak at appropriate positions).

During the testing, I found that if the addOuterBraces flag is turned on, Mathjax will regard the entire formula content as a single texAtom and refuse to perform line breaks on it. To conduct the test, [I turned off this flag](https://github.com/mhchem/mhchemParser/pull/4/files#diff-793f8c78b54dd8f588bdc8359c65fd79efce04c28bb49aff489759a20b0940a9L39-L45), and I'm not sure what will happen if I do so.

Currently, this mr is only for test. Waiting the official release of Mathjax V4.